### PR TITLE
Update versions - 2019-05-08, fix _get_config function and added debug option in 8/debian9/8.0/docker-entrypoint.sh

### DIFF
--- a/5/debian9/5.6/Dockerfile
+++ b/5/debian9/5.6/Dockerfile
@@ -76,7 +76,7 @@ RUN set -ex; \
   apt-key list > /dev/null
 
 ENV MYSQL_MAJOR 5.6
-ENV MYSQL_VERSION 5.6.43-1debian9
+ENV MYSQL_VERSION 5.6.44-1debian9
 
 RUN DEBIAN_RELASE=$(cat /etc/*-release | grep PRETTY_NAME | sed  's/.*(//;s/).*//') \
     && echo "deb http://repo.mysql.com/apt/debian/ $DEBIAN_RELASE mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list

--- a/5/debian9/5.7/Dockerfile
+++ b/5/debian9/5.7/Dockerfile
@@ -82,7 +82,7 @@ RUN set -ex; \
   apt-key list > /dev/null
 
 ENV MYSQL_MAJOR 5.7
-ENV MYSQL_VERSION 5.7.25-1debian9
+ENV MYSQL_VERSION 5.7.26-1debian9
 
 RUN DEBIAN_RELASE=$(cat /etc/*-release | grep PRETTY_NAME | sed  's/.*(//;s/).*//') \
     && echo "deb http://repo.mysql.com/apt/debian/ $DEBIAN_RELASE mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list

--- a/8/debian9/8.0/Dockerfile
+++ b/8/debian9/8.0/Dockerfile
@@ -82,7 +82,7 @@ RUN set -ex; \
   apt-key list > /dev/null
 
 ENV MYSQL_MAJOR 8.0
-ENV MYSQL_VERSION 8.0.15-1debian9
+ENV MYSQL_VERSION 8.0.16-2debian9
 
 RUN DEBIAN_RELASE=$(cat /etc/*-release | grep PRETTY_NAME | sed  's/.*(//;s/).*//') \
     && echo "deb http://repo.mysql.com/apt/debian/ $DEBIAN_RELASE mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list

--- a/8/debian9/8.0/docker-entrypoint.sh
+++ b/8/debian9/8.0/docker-entrypoint.sh
@@ -16,7 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-set -eo pipefail
+if [[ ! -z "${DEBUG_DOCKER_ENTERYPOINT}" ]]; then
+	set -x
+else
+	set -eo pipefail
+fi
+
 shopt -s nullglob
 
 # if command starts with an option, prepend mysqld
@@ -76,7 +81,7 @@ _check_config() {
 # latter only show values present in config files, and not server defaults
 _get_config() {
 	local conf="$1"; shift
-	"$@" --verbose --help --log-bin-index="$(mktemp -u)" 2>/dev/null | awk '$1 == "'"$conf"'" && $3=="" { print $2 }'
+        "$@" --verbose --help 2>/dev/null | grep "^$conf" | awk '$1 == "'"$conf"'" { print $2; exit }'
 }
 
 # allow the container to be started with `--user`

--- a/8/debian9/8.0/docker-entrypoint.sh
+++ b/8/debian9/8.0/docker-entrypoint.sh
@@ -18,6 +18,8 @@
 
 # Enable bash debug if DEBUG_DOCKER_ENTERYPOINT exsists
 if [[ ! -z "${DEBUG_DOCKER_ENTERYPOINT}" ]]; then
+	echo "!!! WARNING: DEBUG_DOCKER_ENTERYPOINT is enabled!"
+	echo "!!! WARNING: Use only for debugging. Do not use in production!"
 	set -x
 fi
 

--- a/8/debian9/8.0/docker-entrypoint.sh
+++ b/8/debian9/8.0/docker-entrypoint.sh
@@ -16,12 +16,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# Enable bash debug if DEBUG_DOCKER_ENTERYPOINT exsists
 if [[ ! -z "${DEBUG_DOCKER_ENTERYPOINT}" ]]; then
 	set -x
-else
-	set -eo pipefail
 fi
 
+set -eo pipefail
 shopt -s nullglob
 
 # if command starts with an option, prepend mysqld

--- a/8/debian9/8.0/docker-entrypoint.sh
+++ b/8/debian9/8.0/docker-entrypoint.sh
@@ -115,7 +115,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo 'Certificates initialized'
 		fi
 
-                SOCKET="/var/run/mysqld/mysqld.sock"
+		SOCKET="$(_get_config 'socket' "$@")"
 		"$@" --skip-networking --socket="${SOCKET}" &
 		pid="$!"
 

--- a/8/debian9/8.0/docker-entrypoint.sh
+++ b/8/debian9/8.0/docker-entrypoint.sh
@@ -115,7 +115,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo 'Certificates initialized'
 		fi
 
-		SOCKET="$(_get_config 'socket' "$@")"
+                SOCKET="/var/run/mysqld/mysqld.sock"
 		"$@" --skip-networking --socket="${SOCKET}" &
 		pid="$!"
 

--- a/8/debian9/8.0/docker-entrypoint.sh
+++ b/8/debian9/8.0/docker-entrypoint.sh
@@ -16,7 +16,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# Enable bash debug if DEBUG_DOCKER_ENTERYPOINT exsists
+# Enable bash debug if DEBUG_DOCKER_ENTERYPOINT exists
 if [[ ! -z "${DEBUG_DOCKER_ENTERYPOINT}" ]]; then
 	echo "!!! WARNING: DEBUG_DOCKER_ENTERYPOINT is enabled!"
 	echo "!!! WARNING: Use only for debugging. Do not use in production!"

--- a/8/debian9/8.0/docker-entrypoint.sh
+++ b/8/debian9/8.0/docker-entrypoint.sh
@@ -83,7 +83,7 @@ _check_config() {
 # latter only show values present in config files, and not server defaults
 _get_config() {
 	local conf="$1"; shift
-	"$@" --verbose --help 2>/dev/null | grep "^$conf" | awk '$1 == "'"$conf"'" { print $2; exit }'
+	"$@" --verbose --help --log-bin-index="$(mktemp -u)" 2>/dev/null | grep "^$conf" | awk '$1 == "'"$conf"'" { print $2; exit }'
 }
 
 # allow the container to be started with `--user`

--- a/8/debian9/8.0/docker-entrypoint.sh
+++ b/8/debian9/8.0/docker-entrypoint.sh
@@ -81,7 +81,7 @@ _check_config() {
 # latter only show values present in config files, and not server defaults
 _get_config() {
 	local conf="$1"; shift
-        "$@" --verbose --help 2>/dev/null | grep "^$conf" | awk '$1 == "'"$conf"'" { print $2; exit }'
+	"$@" --verbose --help 2>/dev/null | grep "^$conf" | awk '$1 == "'"$conf"'" { print $2; exit }'
 }
 
 # allow the container to be started with `--user`

--- a/versions.yaml
+++ b/versions.yaml
@@ -30,10 +30,10 @@ versions:
     repo: mysql8
     templateSubDir: debian9
     tags:
-      - '8.0.15-debian9'
+      - '8.0.16-debian9'
       - '8.0-debian9'
       - '8-debian9'
-      - '8.0.15'
+      - '8.0.16'
       - '8.0'
       - '8'
       - 'latest'
@@ -41,7 +41,7 @@ versions:
     packages:
       gosu: *gosu
       mysql:
-        version: 8.0.15-1debian9
+        version: 8.0.16-2debian9
         major: '8.0'
         gpg: *gpg
     excludeTests: *nonExporterTests
@@ -51,10 +51,10 @@ versions:
     repo: mysql5
     templateSubDir: debian9
     tags:
-      - '5.7.25-debian9'
+      - '5.7.26-debian9'
       - '5.7-debian9'
       - '5-debian9'
-      - '5.7.25'
+      - '5.7.26'
       - '5.7'
       - '5'
       - 'latest'
@@ -62,7 +62,7 @@ versions:
     packages:
       gosu: *gosu
       mysql:
-        version: 5.7.25-1debian9
+        version: 5.7.26-1debian9
         major: '5.7'
         gpg: *gpg
     excludeTests: *nonExporterTests
@@ -72,15 +72,15 @@ versions:
     repo: mysql5
     templateSubDir: debian9
     tags:
-      - '5.6.43-debian9'
+      - '5.6.44-debian9'
       - '5.6-debian9'
-      - '5.6.43'
+      - '5.6.44'
       - '5.6'
     from: *from9
     packages:
       gosu: *gosu
       mysql:
-        version: 5.6.43-1debian9
+        version: 5.6.44-1debian9
         major: '5.6'
         gpg: *gpg
     excludeTests: *nonExporterTests


### PR DESCRIPTION
We need this changes because old way to get socket value from mysqld starts work wrong with
new version of package. New version of _get_config function always return one line.

Example output of old and new version:

```
root@9a92f724a4bf:/# export conf="socket"
root@9a92f724a4bf:/# /usr/sbin/mysqld --verbose --help --log-bin-index="$(mktemp -u)" 2>/dev/null | awk '$1 == "'"$conf"'" && $3=="" { print $2 }'
creation.
creation.
/var/run/mysqld/mysqld.sock
root@9a92f724a4bf:/# /usr/sbin/mysqld --verbose --help 2>/dev/null | grep "^$conf" | awk '$1 == "'"$conf"'" { print $2; exit }'
/var/run/mysqld/mysqld.sock
```