### PR TITLE
Use MySQL release keys that are still valid

### DIFF
--- a/5/debian11/5.7/Dockerfile
+++ b/5/debian11/5.7/Dockerfile
@@ -49,7 +49,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 # gpg: key 3A79BD29: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
-	key='859BE8D7C586F538430B19C2467B942D3A79BD29'; \
+	key='BCA43417C3B485DD128EC6D4B7B3B788A8D3785C'; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	mkdir -p /etc/apt/keyrings; \

--- a/8/debian11/8.0/Dockerfile
+++ b/8/debian11/8.0/Dockerfile
@@ -58,8 +58,8 @@ RUN set -eux; \
 	rm -rf "$GNUPGHOME"
 
 ENV MYSQL_MAJOR 8.0
-ENV MYSQL_VERSION 8.0.36-1debian11
-ENV C2D_RELEASE 8.0.36
+ENV MYSQL_VERSION 8.0.35-1debian11
+ENV C2D_RELEASE 8.0.35
 
 RUN echo "deb [ signed-by=/etc/apt/keyrings/mysql.gpg ] http://repo.mysql.com/apt/debian/  bullseye  mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 

--- a/8/debian11/8.0/Dockerfile
+++ b/8/debian11/8.0/Dockerfile
@@ -48,8 +48,8 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
-# gpg: key 3A79BD29: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
-	key='859BE8D7C586F538430B19C2467B942D3A79BD29'; \
+# gpg: key A8D3785C: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
+	key='BCA43417C3B485DD128EC6D4B7B3B788A8D3785C'; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	mkdir -p /etc/apt/keyrings; \
@@ -58,8 +58,8 @@ RUN set -eux; \
 	rm -rf "$GNUPGHOME"
 
 ENV MYSQL_MAJOR 8.0
-ENV MYSQL_VERSION 8.0.34-1debian11
-ENV C2D_RELEASE 8.0.34
+ENV MYSQL_VERSION 8.0.36-1debian11
+ENV C2D_RELEASE 8.0.36
 
 RUN echo "deb [ signed-by=/etc/apt/keyrings/mysql.gpg ] http://repo.mysql.com/apt/debian/  bullseye  mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 

--- a/8/debian11/8.0/Dockerfile
+++ b/8/debian11/8.0/Dockerfile
@@ -48,7 +48,7 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
-# gpg: key A8D3785C: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
+# gpg: key 3A79BD29: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
 	key='BCA43417C3B485DD128EC6D4B7B3B788A8D3785C'; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \

--- a/versions.yaml
+++ b/versions.yaml
@@ -29,13 +29,13 @@ versions:
     mysql:
       gpg: BCA43417C3B485DD128EC6D4B7B3B788A8D3785C
       major: '8.0'
-      version: 8.0.36
+      version: 8.0.35
   repo: mysql8
   tags:
-  - 8.0.36-debian11
+  - 8.0.35-debian11
   - 8.0-debian11
   - 8-debian11
-  - 8.0.36
+  - 8.0.35
   - '8.0'
   - '8'
   - latest

--- a/versions.yaml
+++ b/versions.yaml
@@ -52,7 +52,7 @@ versions:
       gpg: B42F6819007F00F88E364FD4036A9C25BF357DD4
       version: '1.16'
     mysql:
-      gpg: 859BE8D7C586F538430B19C2467B942D3A79BD29
+      gpg: BCA43417C3B485DD128EC6D4B7B3B788A8D3785C
       major: '5.7'
       version: 5.7.42
   repo: mysql5

--- a/versions.yaml
+++ b/versions.yaml
@@ -27,15 +27,15 @@ versions:
       gpg: B42F6819007F00F88E364FD4036A9C25BF357DD4
       version: '1.16'
     mysql:
-      gpg: 859BE8D7C586F538430B19C2467B942D3A79BD29
+      gpg: BCA43417C3B485DD128EC6D4B7B3B788A8D3785C
       major: '8.0'
-      version: 8.0.34
+      version: 8.0.36
   repo: mysql8
   tags:
-  - 8.0.34-debian11
+  - 8.0.36-debian11
   - 8.0-debian11
   - 8-debian11
-  - 8.0.34
+  - 8.0.36
   - '8.0'
   - '8'
   - latest


### PR DESCRIPTION
The old release keys have expired. These new release keys are used for signing releases from 8.0.36, and so the version of MySQL 8 has been updated to this version.

I haven't been able to test that this works because the base image for the Dockerfile requires auth:

```
ERROR: failed to solve: marketplace.gcr.io/google/c2d-debian11: pulling from host marketplace.gcr.io failed with status code [manifests latest]: 401 Unauthorized
```

This fixes #98 which is blocking CI and presubmits for google/trillian and google/certificate-transparency-go.
